### PR TITLE
feat(Mauga): Open queue hp mauga

### DIFF
--- a/src/constants/adj_constants.opy
+++ b/src/constants/adj_constants.opy
@@ -191,7 +191,7 @@ globalvar SETTING_ECHO_TANK_HP = createWorkshopSetting(bool, "General Changes", 
 
 # Mauga
 #!define ADJ_MAUGA_AMMO 250
-#!define ADJ_MAUGA_ARMOR 125
+#!define ADJ_MAUGA_ARMOR 200
 #!define ADJ_MAUGA_BASE_ARMOR_DUPLICATE 122
 #!define ADJ_MAUGA_ARMOR_DUPLICATE 125
 #!define ADJ_MAUGA_BURN_DPS 20

--- a/src/constants/adj_constants.opy
+++ b/src/constants/adj_constants.opy
@@ -190,11 +190,11 @@ globalvar SETTING_ECHO_TANK_HP = createWorkshopSetting(bool, "General Changes", 
 #!define ADJ_LUCIO_ULT_COST 2940
 
 # Mauga
-#!define ADJ_MAUGA_AMMO 250
+#!define ADJ_MAUGA_AMMO 300
 #!define ADJ_MAUGA_ARMOR 200
 #!define ADJ_MAUGA_BASE_ARMOR_DUPLICATE 122
 #!define ADJ_MAUGA_ARMOR_DUPLICATE 125
-#!define ADJ_MAUGA_BURN_DPS 20
+#!define ADJ_MAUGA_BURN_DPS 25
 #!define ADJ_MAUGA_BURN_RATE 7.9
 # burn rate needs to be set slightly lower than target variable due to a rounding error
 #!define ADJ_MAUGA_BURN_DURATION 3.5
@@ -202,12 +202,12 @@ globalvar SETTING_ECHO_TANK_HP = createWorkshopSetting(bool, "General Changes", 
 #!define ADJ_MAUGA_CARDIAC_COOLDOWN 12
 #!define ADJ_MAUGA_CARDIAC_DAMAGE_REDUCTION 0.4
 #!define ADJ_MAUGA_CARDIAC_LIFESTEAL 0.7
-#!define ADJ_MAUGA_CHAINGUN_DAMAGE 3.3
+#!define ADJ_MAUGA_CHAINGUN_DAMAGE 3.55
 #!define ADJ_MAUGA_HEALTH 375
 #!define ADJ_MAUGA_BASE_HEALTH_DUPLICATE 228
 #!define ADJ_MAUGA_HEALTH_DUPLICATE 250
 #!define ADJ_MAUGA_OVERRUN_COOLDOWN 8
-#!define ADJ_MAUGA_STOMP_DAMAGE 50
+#!define ADJ_MAUGA_STOMP_DAMAGE 75
 #!define ADJ_MAUGA_ULT_COST 2400
 
 # Mei

--- a/src/heroes/lucio/aura.opy
+++ b/src/heroes/lucio/aura.opy
@@ -11,12 +11,12 @@ rule "[lucio/aura.opy]: Allow self healing during heal aura":
     popSelfHealing(Button.ABILITY_1)
 
 
-rule "[illari/init.opy]: Correct Aura self healing":
-    @Event playerDealtHealing
-    @Hero lucio
-    @Condition healee == healer
-    @Condition eventAbility == Button.ABILITY_1
-    @Condition not eventPlayer.isUsingAbility2()
+# rule "[illari/init.opy]: Correct Aura self healing":
+#     @Event playerDealtHealing
+#     @Hero lucio
+#     @Condition healee == healer
+#     @Condition eventAbility == Button.ABILITY_1
+#     @Condition not eventPlayer.isUsingAbility2()
 
-    heal(healer, healer, eventHealing * (OW2_LUCIO_ALLY_HEALING / OW2_LUCIO_SELF_HEALING) - eventHealing)
+#     heal(healer, healer, eventHealing * (OW2_LUCIO_ALLY_HEALING / OW2_LUCIO_SELF_HEALING) - eventHealing)
     

--- a/src/heroes/mauga/init.opy
+++ b/src/heroes/mauga/init.opy
@@ -9,6 +9,10 @@ rule "[mauga/init.opy]: Initialize Mauga":
     @Hero mauga
     @Condition eventPlayer.call_init
 
+    setCustomHp(
+        ADJ_MAUGA_HEALTH_DUPLICATE if eventPlayer.isDuplicatingAHero() or SETTING_ECHO_TANK_HP else ADJ_MAUGA_HEALTH, 
+        ADJ_MAUGA_ARMOR_DUPLICATE if eventPlayer.isDuplicatingAHero() or SETTING_ECHO_TANK_HP else ADJ_MAUGA_ARMOR, 
+        0)
     setUltCost(ADJ_MAUGA_ULT_COST)
 
     removeTankPassive()

--- a/src/heroes/mauga/init.opy
+++ b/src/heroes/mauga/init.opy
@@ -6,7 +6,7 @@
 
 rule "[mauga/init.opy]: Initialize Mauga":
     @Event eachPlayer
-    @Hero mauga
+    @Condition eventPlayer.hero_setup == Hero.MAUGA
     @Condition eventPlayer.call_init
 
     setCustomHp(
@@ -42,12 +42,3 @@ rule "[mauga/init.opy]: Reduce Mauga stomp damage":
     @Condition eventAbility == Button.ABILITY_1
 
     heal(victim, null, eventDamage - ((ADJ_MAUGA_STOMP_DAMAGE / OW2_MAUGA_STOMP_DAMAGE) * eventDamage/eventPlayer._base_damage_scalar))
-
-
-rule "[mauga/init.opy]: (Duplicate) Initialize Mauga":
-    @Event eachPlayer
-    @Condition eventPlayer.isDuplicatingAHero() == Hero.MAUGA
-    @Condition eventPlayer.call_init
-
-    eventPlayer.addHealthPool(Health.NORMAL, ADJ_MAUGA_HEALTH_DUPLICATE - ADJ_MAUGA_BASE_HEALTH_DUPLICATE, true, true)
-    eventPlayer.addHealthPool(Health.ARMOR, ADJ_MAUGA_ARMOR_DUPLICATE - ADJ_MAUGA_BASE_ARMOR_DUPLICATE, true, true)

--- a/src/heroes/mauga/init.opy
+++ b/src/heroes/mauga/init.opy
@@ -28,17 +28,17 @@ rule "[mauga/init.opy]: Initialize Mauga":
     eventPlayer.call_init = false
 
 
-rule "[mauga/init.opy]: Increase Mauga melee damage":
+rule "[mauga/init.opy]: Increase Mauga melee and Stomp damage":
     @Event playerDealtDamage
     @Hero mauga
-    @Condition eventAbility in [Button.MELEE]
+    @Condition eventAbility in [Button.MELEE, Button.ABILITY_1]
 
     damage(victim, attacker, (eventDamage/eventPlayer._base_damage_scalar - eventDamage)/eventPlayer._base_damage_scalar)
 
 
-rule "[mauga/init.opy]: Reduce Mauga stomp damage":
-    @Event playerDealtDamage
-    @Hero mauga
-    @Condition eventAbility == Button.ABILITY_1
+# rule "[mauga/init.opy]: Reduce Mauga stomp damage":
+#     @Event playerDealtDamage
+#     @Hero mauga
+#     @Condition eventAbility == Button.ABILITY_1
 
-    heal(victim, null, eventDamage - ((ADJ_MAUGA_STOMP_DAMAGE / OW2_MAUGA_STOMP_DAMAGE) * eventDamage/eventPlayer._base_damage_scalar))
+#     heal(victim, null, eventDamage - ((ADJ_MAUGA_STOMP_DAMAGE / OW2_MAUGA_STOMP_DAMAGE) * eventDamage/eventPlayer._base_damage_scalar))

--- a/src/heroes/mauga/init.opy
+++ b/src/heroes/mauga/init.opy
@@ -9,46 +9,17 @@ rule "[mauga/init.opy]: Initialize Mauga":
     @Hero mauga
     @Condition eventPlayer.call_init
 
-    eventPlayer.removeAllHealthPools()
-    wait()
-    eventPlayer.setMaxHealth(100.001) # DO NOT REMOVE THIS LINE
-    wait() # DO NOT REMOVE THIS LINE
-    eventPlayer.setMaxHealth(100)
-
-    eventPlayer.setHealingReceived(0)
-    wait()
-    eventPlayer.setHealth(649.997)
-    # using magic numbers in this code for the time being until it can be further understood
-
-    eventPlayer.addHealthPool(Health.NORMAL, 1, true, true)
-    eventPlayer.addHealthPool(Health.ARMOR, 1, true, true)
-    eventPlayer.addHealthPool(Health.SHIELDS, 1, true, true)
-    eventPlayer.removeAllHealthPools()
-
-    resetStats()
-    resetStatuses()
-    enableAllAbilities()
-
     setUltCost(ADJ_MAUGA_ULT_COST)
 
     removeTankPassive()
     removeSelfHealing()
-
-
-    if ceil(eventPlayer.getMaxHealth()) != 650:
-        goto RULE_START
     
     setBaseDamage(eventPlayer, ADJ_MAUGA_CHAINGUN_DAMAGE/OW2_MAUGA_CHAINGUN_DAMAGE)
-    
-    eventPlayer.setHealingDealt(percent(ADJ_MAUGA_CARDIAC_LIFESTEAL/OW2_MAUGA_CARDIAC_LIFESTEAL))
+    setBaseHealing(eventPlayer, ADJ_MAUGA_CARDIAC_LIFESTEAL/OW2_MAUGA_CARDIAC_LIFESTEAL)
+
     eventPlayer.startScalingSize(0.94, true)
 
     eventPlayer.balance_change_check = false
-    
-    getPlayersOnHero(Hero.MAUGA, eventPlayer.getTeam()).setHealth(350)
-    heal(eventPlayer, null, 350)
-    # waitUntil(not eventPlayer.isInSpawnRoom(), Math.INFINITY)
-    # damage(eventPlayer, null, 100.99)
 
     eventPlayer.call_init = false
 

--- a/src/utilities/custom_hp.opy
+++ b/src/utilities/custom_hp.opy
@@ -28,7 +28,7 @@ def clearCustomHp():
 
     eventPlayer.removeAllHealthPools()
     wait()
-    eventPlayer.setMaxHealth(100.001) # DO NOT REMOVE THIS LINE
+    eventPlayer.setMaxHealth(99.999) # DO NOT REMOVE THIS LINE
     wait() # DO NOT REMOVE THIS LINE
     eventPlayer.setMaxHealth(100)
 


### PR DESCRIPTION
for spilo season 9 6v6

Open queue Mauga health (375) and armor (200) with consistently working 150 overhealth.
Also tested echo duplicate on Mauga works.

See #9 to get insight on how the fix might work