### PR TITLE
redone doomfist logic (for deployable damage)

### DIFF
--- a/src/heroes/doomfist/init.opy
+++ b/src/heroes/doomfist/init.opy
@@ -20,7 +20,7 @@ rule "[doomfist/init.opy]: Initialize Doomfist":
     removeSelfHealing()
 
     if not eventPlayer.isDuplicatingAHero():
-        setBaseDamage(eventPlayer, ADJ_DOOMFIST_ROCKET_PUNCH_TOTAL_DAMAGE/OW2_DOOMFIST_ROCKET_PUNCH_TOTAL_DAMAGE)
+        setBaseDamage(eventPlayer, ADJ_DOOMFIST_SEISMIC_SLAM_DAMAGE/OW2_DOOMFIST_SEISMIC_SLAM_DAMAGE)
 
     eventPlayer.call_init = false
     eventPlayer.max_health_scaler = (ADJ_DOOMFIST_BEST_DEFENSE / OW2_DOOMFIST_BEST_DEFENSE)

--- a/src/heroes/doomfist/punch.opy
+++ b/src/heroes/doomfist/punch.opy
@@ -10,8 +10,12 @@ rule "[doomfist/punch.opy]: Initialize rocket punch":
     @Condition eventPlayer.isFiringSecondaryFire()
     @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
 
+    setBaseDamage(eventPlayer, ADJ_DOOMFIST_ROCKET_PUNCH_TOTAL_DAMAGE/OW2_DOOMFIST_ROCKET_PUNCH_TOTAL_DAMAGE)
     eventPlayer.punched_victims = []
     eventPlayer.wall_impacted_victims = []
+    waitUntil(not eventPlayer.isFiringSecondaryFire(), 4)
+    wait(0.2)
+    setBaseDamage(eventPlayer, ADJ_DOOMFIST_SEISMIC_SLAM_DAMAGE/OW2_DOOMFIST_SEISMIC_SLAM_DAMAGE)
 
 
 # DO NOT switch the order of this rule with the next rule


### PR DESCRIPTION
Keeps all damage intact, but allows Doomfist's primary fire base damage to not be set so low. This way, Doomfist can deal more accurate damage to deployables.