### PR TITLE
fix: completely reset all abilities

### DIFF
--- a/src/utilities/hero_reset.opy
+++ b/src/utilities/hero_reset.opy
@@ -37,10 +37,10 @@ def enableAllAbilities():
     eventPlayer.allowButton(Button.ULTIMATE)
 
     eventPlayer.allowButton(Button.MELEE)
-    # eventPlayer.allowButton(Button.JUMP)
-    # eventPlayer.allowButton(Button.CROUCH)
-    # eventPlayer.allowButton(Button.RELOAD)
-    # eventPlayer.allowButton(Button.INTERACT)
+    eventPlayer.allowButton(Button.JUMP)
+    eventPlayer.allowButton(Button.CROUCH)
+    eventPlayer.allowButton(Button.RELOAD)
+    eventPlayer.allowButton(Button.INTERACT)
 
     eventPlayer.setPrimaryFireEnabled(true)
     eventPlayer.setSecondaryFireEnabled(true)
@@ -49,9 +49,9 @@ def enableAllAbilities():
     eventPlayer.setUltEnabled(true)
 
     eventPlayer.setMeleeEnabled(true)
-    # eventPlayer.setJumpEnabled(true)
-    # eventPlayer.setCrouchEnabled(true)
-    # eventPlayer.setReloadEnabled(true)
+    eventPlayer.setJumpEnabled(true)
+    eventPlayer.setCrouchEnabled(true)
+    eventPlayer.setReloadEnabled(true)
 
 
 def disableAllAbilities():
@@ -64,10 +64,10 @@ def disableAllAbilities():
     eventPlayer.disallowButton(Button.ULTIMATE)
 
     eventPlayer.disallowButton(Button.MELEE)
-    # eventPlayer.disallowButton(Button.JUMP)
-    # eventPlayer.disallowButton(Button.CROUCH)
-    # eventPlayer.disallowButton(Button.RELOAD)
-    # eventPlayer.disallowButton(Button.INTERACT)
+    eventPlayer.disallowButton(Button.JUMP)
+    eventPlayer.disallowButton(Button.CROUCH)
+    eventPlayer.disallowButton(Button.RELOAD)
+    eventPlayer.disallowButton(Button.INTERACT)
 
     eventPlayer.setPrimaryFireEnabled(false)
     eventPlayer.setSecondaryFireEnabled(false)
@@ -76,9 +76,9 @@ def disableAllAbilities():
     eventPlayer.setUltEnabled(false)
 
     eventPlayer.setMeleeEnabled(false)
-    # eventPlayer.setJumpEnabled(false)
-    # eventPlayer.setCrouchEnabled(false)
-    # eventPlayer.setReloadEnabled(false)
+    eventPlayer.setJumpEnabled(false)
+    eventPlayer.setCrouchEnabled(false)
+    eventPlayer.setReloadEnabled(false)
 
 
 def resetStats():
@@ -87,17 +87,17 @@ def resetStats():
     setBaseDamage(eventPlayer, 1)
     eventPlayer.setDamageReceived(100)
     eventPlayer.setProjectileSpeed(100)
-    # eventPlayer.setProjectileGravity(100)
+    eventPlayer.setProjectileGravity(100)
     setBaseHealing(eventPlayer, 1)
     eventPlayer.setHealingReceived(100)
     eventPlayer.setKnockbackReceived(100)
     eventPlayer.setKnockbackDealt(100)
-    # eventPlayer.setGravity(100)
-    # eventPlayer.setJumpVerticalSpeed(100)
+    eventPlayer.setGravity(100)
+    eventPlayer.setJumpVerticalSpeed(100)
     eventPlayer.setMoveSpeed(100)
 
     eventPlayer.stopScalingSize()
-    # eventPlayer.stopScalingBarriers()
+    eventPlayer.stopScalingBarriers()
     eventPlayer.max_health_scaler = 1
 
 

--- a/src/utilities/hero_reset.opy
+++ b/src/utilities/hero_reset.opy
@@ -93,7 +93,7 @@ def resetStats():
     eventPlayer.setKnockbackReceived(100)
     eventPlayer.setKnockbackDealt(100)
     eventPlayer.setGravity(100)
-    eventPlayer.setJumpVerticalSpeed(100)
+    # eventPlayer.setJumpVerticalSpeed(100) # might be responsible for jump bug
     eventPlayer.setMoveSpeed(100)
 
     eventPlayer.stopScalingSize()

--- a/src/utilities/hero_reset.opy
+++ b/src/utilities/hero_reset.opy
@@ -92,12 +92,13 @@ def resetStats():
     eventPlayer.setHealingReceived(100)
     eventPlayer.setKnockbackReceived(100)
     eventPlayer.setKnockbackDealt(100)
-    eventPlayer.setGravity(100)
+    # eventPlayer.setGravity(100)
     # eventPlayer.setJumpVerticalSpeed(100) # might be responsible for jump bug
     eventPlayer.setMoveSpeed(100)
 
     eventPlayer.stopScalingSize()
     eventPlayer.stopScalingBarriers()
+    eventPlayer.stopForcingButton(Button.PRIMARY_FIRE) # prevent wholehog from keeping primary fire held
     eventPlayer.max_health_scaler = 1
 
 


### PR DESCRIPTION
I think we commented out some of the reset abilities while debugging mauga overhealth or slow initialization, but they never got reverted. I turned them back on and can't really notice a difference.

Feel free to reject since gamemode functions well as is.