### PR TITLE
style: more readable/maintainable cassidy falloff logic

### DIFF
--- a/src/heroes/mccree/init.opy
+++ b/src/heroes/mccree/init.opy
@@ -1,7 +1,7 @@
 #!mainFile "../../dev_main.opy"
 
 # #!include "heroes/mccree/deadeye.opy"
-# !include "heroes/mccree/peacekeeper.opy"
+#!include "heroes/mccree/peacekeeper.opy"
 # #!include "heroes/mccree/roll.opy"
 
 

--- a/src/heroes/mccree/peacekeeper.opy
+++ b/src/heroes/mccree/peacekeeper.opy
@@ -9,7 +9,7 @@
 #!define expectedCassidyDamage(distance) (eventDamage/eventPlayer._base_damage_scalar)*(ADJCassidyFalloff(distance)/OW2CassidyFalloff(distance))
 
 
-rule "[mccree/peacekeeper.opy]: Increase Peacekeeper damage range":
+rule "[mccree/peacekeeper.opy]: Increase Peacekeeper falloff damage range":
     @Event playerDealtDamage
     @Hero cassidy
     @Condition eventAbility == Button.PRIMARY_FIRE

--- a/src/heroes/mccree/peacekeeper.opy
+++ b/src/heroes/mccree/peacekeeper.opy
@@ -1,40 +1,17 @@
 #!mainFile "../../dev_main.opy"
 
-playervar cassidy_shot_distance
-playervar cassidy_damage_base
-playervar ow2_cassidy_damage_falloff_scalar
-playervar adj_cassidy_damage_falloff_scalar
-playervar expected_cassidy_damage
-
 
 # Damage falloff derived from Marblr's "How Damage Falloff is Calculated" video: https://youtu.be/VL2VnkNJPpE
-#!define ADJCASSIDYN(d) ((d - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(ADJ_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE))
-#!define OW2CASSIDYN(d) ((d - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(OW2_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE))
-#!define ADJCassidyFalloff(d) ((ADJCASSIDYN(d)) * ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - ADJCASSIDYN(d)))
-#!define OW2CassidyFalloff(d) ((OW2CASSIDYN(d)) * OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - OW2CASSIDYN(d)))
+#!define ADJCASSIDYN(distance) ((distance - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(ADJ_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE))
+#!define OW2CASSIDYN(distance) ((distance - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(OW2_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE))
+#!define ADJCassidyFalloff(distance) clamp((ADJCASSIDYN(distance)) * ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - ADJCASSIDYN(distance)), 0, 1)
+#!define OW2CassidyFalloff(distance) clamp((OW2CASSIDYN(distance)) * OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - OW2CASSIDYN(distance)), 0, 1)
+#!define expectedCassidyDamage(distance) (eventDamage/eventPlayer._base_damage_scalar)*(ADJCassidyFalloff(distance)/OW2CassidyFalloff(distance))
 
 
 rule "[mccree/peacekeeper.opy]: Increase Peacekeeper damage range":
     @Event playerDealtDamage
     @Hero cassidy
     @Condition eventAbility == Button.PRIMARY_FIRE
-    
-    eventPlayer.cassidy_shot_distance = distance(attacker.getEyePosition(), victim)
-    eventPlayer.ow2_cassidy_damage_falloff_scalar = OW2CassidyFalloff(eventPlayer.cassidy_shot_distance)
-    # Cap min/max scalar
-    if eventPlayer.ow2_cassidy_damage_falloff_scalar > 1: # Max damage scalar
-        eventPlayer.ow2_cassidy_damage_falloff_scalar = 1
-    elif eventPlayer.ow2_cassidy_damage_falloff_scalar < OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR: # Min damage scalar
-        eventPlayer.ow2_cassidy_damage_falloff_scalar = OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR
 
-    eventPlayer.cassidy_damage_base = eventDamage/eventPlayer.ow2_cassidy_damage_falloff_scalar
-    
-    eventPlayer.adj_cassidy_damage_falloff_scalar = ADJCassidyFalloff(eventPlayer.cassidy_shot_distance)
-    # Cap min/max scalar
-    if eventPlayer.adj_cassidy_damage_falloff_scalar > 1: # Max damage scalar
-        eventPlayer.adj_cassidy_damage_falloff_scalar = 1
-    elif eventPlayer.adj_cassidy_damage_falloff_scalar < ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR: # Min damage scalar
-        eventPlayer.adj_cassidy_damage_falloff_scalar = ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR
-
-    eventPlayer.expected_cassidy_damage = eventPlayer.cassidy_damage_base * eventPlayer.adj_cassidy_damage_falloff_scalar
-    damage(victim, attacker, eventPlayer.expected_cassidy_damage - eventDamage)
+    damage(victim, attacker, (expectedCassidyDamage(distance(attacker.getEyePosition(), victim)) - eventDamage)/eventPlayer._base_damage_scalar)

--- a/src/utilities/debug.opy
+++ b/src/utilities/debug.opy
@@ -36,7 +36,7 @@ rule "[utilities/debug.opy]: player debug (Top Right)":
     @Condition DEBUG_MODE == true
 
     hudHeader(eventPlayer, "Event Player", HudPosition.RIGHT, 0, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "hero_initialized = {}".format(eventPlayer.hero_initialized), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "hero_initialized = {}".format(eventPlayer.hero_initialized), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     #  hudSubheader(eventPlayer, "_regen_passive_id = {}".format(eventPlayer._regen_passive_id), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     #  hudSubheader(eventPlayer, "_regen_delay = {}".format(eventPlayer._regen_delay), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "hero_setup = {}".format(eventPlayer.hero_setup), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
@@ -79,11 +79,11 @@ rule "[utilities/debug.opy]: player debug (Top Right)":
     # hudSubheader(eventPlayer, "getSpeed() = {}".format(eventPlayer.getSpeed()), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "_ult_cost = {}".format(eventPlayer._ult_cost), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "_ult_percent_compensated = {}".format(eventPlayer._ult_percent_compensated), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "getMaxHealth() = {}".format(eventPlayer.getMaxHealth()), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "getHealth() = {}".format(eventPlayer.getHealth()), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "getMaxHealthOfType(NORMAL) = {}".format(eventPlayer.getMaxHealthOfType(Health.NORMAL)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "getMaxHealthOfType(ARMOR) = {}".format(eventPlayer.getMaxHealthOfType(Health.ARMOR)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "getMaxHealthOfType(SHIELDS) = {}".format(eventPlayer.getMaxHealthOfType(Health.SHIELDS)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "getMaxHealth() = {}".format(eventPlayer.getMaxHealth()), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "getHealth() = {}".format(eventPlayer.getHealth()), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "getMaxHealthOfType(NORMAL) = {}".format(eventPlayer.getMaxHealthOfType(Health.NORMAL)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "getMaxHealthOfType(ARMOR) = {}".format(eventPlayer.getMaxHealthOfType(Health.ARMOR)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "getMaxHealthOfType(SHIELDS) = {}".format(eventPlayer.getMaxHealthOfType(Health.SHIELDS)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "getHealthOfType(NORMAL) = {}".format(eventPlayer.getHealthOfType(Health.NORMAL)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "getHealthOfType(ARMOR) = {}".format(eventPlayer.getHealthOfType(Health.ARMOR)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "getHealthOfType(SHIELDS) = {}".format(eventPlayer.getHealthOfType(Health.SHIELDS)), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
@@ -195,7 +195,7 @@ rule "[utilities/debug.opy]: Debug damage instance":
     @Event playerTookDamage
     @Condition DEBUG_MODE
 
-    printLog("attacker={}, victim={}, ability={}, amount={}".format(attacker, victim, eventAbility, eventDamage))
+    printLog("attacker={}, victim={}, ability={}, amount={}, distance={}".format(attacker, victim, eventAbility, eventDamage, distance(attacker.getPosition(), victim.getPosition())))
 
     victim._last_damage_received = eventDamage
     victim._total_damage_received += eventDamage

--- a/src/utilities/macro_functions.opy
+++ b/src/utilities/macro_functions.opy
@@ -37,3 +37,5 @@
                      or player.hasStatusEffect(Status.ASLEEP) \
                      or player.hasStatusEffect(Status.FROZEN) \
                      or player.hasStatusEffect(Status.KNOCKED_DOWN))
+
+#!define clamp(value, low, high) (low if (value < low) else (high if (value > high) else value))


### PR DESCRIPTION
This fix makes it clear how the new damage is calculated and applied.

also replaces all the peacekeeper variables with in-line calculations