### PR TITLE
fix(Mercy): fix valkyrie regen edge cases

### DIFF
--- a/src/heroes/illari/init.opy
+++ b/src/heroes/illari/init.opy
@@ -8,7 +8,7 @@ def initIllari():
     
     setCustomHp(ADJ_ILLARI_HEALTH, 0, 0)
     setUltCost(ADJ_ILLARI_ULT_COST)
-    removeRegenPassive()
+    removeOW2RegenPassive()
 
     if not eventPlayer.isDuplicatingAHero():
         setBaseDamage(eventPlayer, ADJ_ILLARI_SUNSTRUCK_DAMAGE/OW2_ILLARI_SUNSTRUCK_DAMAGE)

--- a/src/heroes/junkerqueen/init.opy
+++ b/src/heroes/junkerqueen/init.opy
@@ -15,7 +15,7 @@ def initJunkerQueen():
         0)
     setUltCost(ADJ_JUNKERQUEEN_ULT_COST)
     removeTankPassive()
-    removeRegenPassive()
+    removeOW2RegenPassive()
 
     setBaseDamage(eventPlayer, ADJ_JUNKERQUEEN_SCATTER_GUN_DAMAGE / OW2_JUNKERQUEEN_SCATTER_GUN_DAMAGE)
     eventPlayer.setHealingDealt(percent(ADJ_JUNKERQUEEN_ADRENALINE_HEAL_MOD / ((ADJ_JUNKERQUEEN_SCATTER_GUN_DAMAGE / OW2_JUNKERQUEEN_SCATTER_GUN_DAMAGE) * OW2_JUNKERQUEEN_ADRENALINE_HEAL_MOD)))

--- a/src/heroes/lifeweaver/init.opy
+++ b/src/heroes/lifeweaver/init.opy
@@ -6,7 +6,7 @@ def initLifeweaver():
     
     setCustomHp(ADJ_LIFEWEAVER_HEALTH, 0, ADJ_LIFEWEAVER_SHIELDS)
     setUltCost(ADJ_LIFEWEAVER_ULT_COST)
-    removeRegenPassive()
+    removeOW2RegenPassive()
 
     setBaseDamage(eventPlayer, ADJ_LIFEWEAVER_THORN_VOLLEY_DAMAGE/OW2_LIFEWEAVER_THORN_VOLLEY_DAMAGE)
 

--- a/src/heroes/mercy/init.opy
+++ b/src/heroes/mercy/init.opy
@@ -1,7 +1,5 @@
 #!mainFile "../../dev_main.opy"
 
-playervar valk_regen_id
-
 
 def initMercy():
     @Name "[mercy/init.opy]: initMercy()"
@@ -25,13 +23,7 @@ rule "[mercy/init.opy]: Reduce Valkyrie healing and force self-healing":
     @Condition eventPlayer.isUsingUltimate()
     
     eventPlayer.setHealingDealt(100)
-    eventPlayer.startHoT(null, OW2_MERCY_VALKYRIE_DURATION, ADJ_MERCY_REGEN_HPS)
-    eventPlayer.valk_regen_id = getLastHoT()
-    damage(eventPlayer, eventPlayer, MIN_DAMAGE)
-    # damage tick doesn't interrupt normal passive unless attributed to a player
+    setRegeneration(ADJ_MERCY_REGEN_HPS)
 
     waitUntil(not eventPlayer.isUsingUltimate(), OW2_MERCY_VALKYRIE_DURATION)
     eventPlayer.setHealingDealt(percent(eventPlayer._base_healing_scalar))
-    stopHoT(eventPlayer.valk_regen_id)
-    eventPlayer.valk_regen_id = null
-    

--- a/src/heroes/moira/init.opy
+++ b/src/heroes/moira/init.opy
@@ -7,6 +7,6 @@ def initMoira():
 
     setCustomHp(ADJ_MOIRA_HEALTH, 0, 0)
     setUltCost(ADJ_MOIRA_ULT_COST)
-    removeRegenPassive()
+    removeOW2RegenPassive()
 
     eventPlayer.hero_initialized = true

--- a/src/heroes/reaper/init.opy
+++ b/src/heroes/reaper/init.opy
@@ -6,7 +6,7 @@ def initReaper():
 
     setCustomHp(ADJ_REAPER_HEALTH, 0, 0)
     setUltCost(ADJ_REAPER_ULT_COST)
-    removeRegenPassive()
+    removeOW2RegenPassive()
 
     setBaseDamage(eventPlayer, ADJ_REAPER_HELLFIRE_SHOTGUNS_DAMAGE / OW2_REAPER_HELLFIRE_SHOTGUNS_DAMAGE)
     setBaseHealing(eventPlayer, ADJ_REAPER_LIFESTEAL_PERCENT / OW2_REAPER_LIFESTEAL_PERCENT)

--- a/src/heroes/roadhog/init.opy
+++ b/src/heroes/roadhog/init.opy
@@ -13,7 +13,7 @@ def initRoadhog():
         0)
     setUltCost(ADJ_ROADHOG_ULT_COST)
     removeTankPassive()
-    removeRegenPassive()
+    removeOW2RegenPassive()
     
     if not eventPlayer.isDuplicatingAHero():
         setBaseDamage(eventPlayer, ADJ_ROADHOG_SCRAP_GUN_DAMAGE/OW2_ROADHOG_SCRAP_GUN_DAMAGE)

--- a/src/passives/support/self_heal.opy
+++ b/src/passives/support/self_heal.opy
@@ -14,8 +14,13 @@ playervar self_heal_pvar
 #!defineMember _suppress_regen_passive self_heal_pvar[5]
 #!defineMember _support_passive_active self_heal_pvar[6]
 #!defineMember _regen_passive_id self_heal_pvar[7]
-#!defineMember _regen_delay self_heal_pvar[8]
-#!defineMember _regen_hps self_heal_pvar[9]
+#!defineMember _passive_regen_delay self_heal_pvar[8]
+#!defineMember _passive_regen_hps self_heal_pvar[9]
+#!defineMember _current_regen_hps self_heal_pvar[10]
+#!defineMember _new_regen_hps self_heal_pvar[11]
+
+subroutine applyRegeneration
+subroutine startPassiveRegeneration
 
 #!include "constants/adj_constants.opy"
 #!include "constants/ow2_constants.opy"
@@ -32,8 +37,10 @@ def resetSelfHealing():
     eventPlayer._suppress_regen_passive = false
     eventPlayer._support_passive_active = true
 
+
 #!define removeRegenPassive()\
     eventPlayer._suppress_regen_passive = true
+
 
 def removeSelfHealing():
     @Name "[passives/support/self_heal.opy]: removeSelfHealing()"
@@ -44,17 +51,25 @@ def removeSelfHealing():
         startHealingModification(eventPlayer, eventPlayer, eventPlayer._self_healing_percent, HealingReeval.RECEIVERS_HEALERS_AND_HEALPERCENT)
         eventPlayer._self_healing_id = getLastHealingModification()
 
+
 #!define evalSelfHealingPercent()\
     eventPlayer._self_healing_percent = 100 if len(eventPlayer._self_healing_source) > 0 else 0\
     eventPlayer._suppress_regen_passive = true if eventPlayer._self_healing_percent > 0 else false
+
 
 #!define pushSelfHealing(button) \
     if (button not in eventPlayer._self_healing_source): eventPlayer._self_healing_source.append(button) \
     evalSelfHealingPercent()
 
+
 #!define popSelfHealing(button) \
     eventPlayer._self_healing_source.remove(button) \
     evalSelfHealingPercent()
+
+
+#!define setRegeneration(hps) \
+    eventPlayer._new_regen_hps = hps \
+    applyRegeneration()
 
 
 rule "[passives/support/self_heal.opy]: Detect healing passive":
@@ -85,35 +100,53 @@ rule "[passives/support/self_heal.opy]: Remove Passive self healing":
     while RULE_CONDITION
 
 
-def activateRegeneration():
-    @Name "[passives/support/self_heal.opy]: activateRegeneration()"
-
-    if eventPlayer.getHealth() < eventPlayer.getMaxHealth():
-        eventPlayer.startHoT(null, Math.INFINITY, eventPlayer._regen_hps)
-        eventPlayer._regen_passive_id = getLastHoT()
-    waitUntil(eventPlayer.getHealth() >= eventPlayer.getMaxHealth(), Math.INFINITY)
-    stopHoT(eventPlayer._regen_passive_id)
-    eventPlayer._regen_passive_id = null
-
-
 rule "[passives/support/self_heal.opy]: Recreate regeneration passive":
     @Event playerTookDamage
     @Condition enable_regeneration or (eventPlayer.getCurrentHero() == Hero.MERCY)
 
-    stopHoT(eventPlayer._regen_passive_id)
-    eventPlayer._regen_passive_id = null
+    async(startPassiveRegeneration, AsyncBehavior.RESTART)
+
+
+def startPassiveRegeneration():
+    @Name "[passives/support/self_heal.opy]: startPassiveRegeneration()"
 
     # logic for calculating regen parameters
-    if eventPlayer.getCurrentHero() == Hero.MERCY and not eventPlayer.isUsingUltimate(): # mercy passive
-        eventPlayer._regen_delay = ADJ_MERCY_PASSIVE_TIMER
-        eventPlayer._regen_hps = ADJ_MERCY_REGEN_HPS
+    if eventPlayer.getCurrentHero() == Hero.MERCY: # mercy passive
+        eventPlayer._passive_regen_delay = ADJ_MERCY_PASSIVE_TIMER if not eventPlayer.isUsingUltimate() else 0
+        eventPlayer._passive_regen_hps = ADJ_MERCY_REGEN_HPS
     elif enable_support_passive and (eventPlayer.getCurrentHero() in getSupportHeroes()): # support passive
-        eventPlayer._regen_delay = ADJ_REGEN_TIMER/2
-        eventPlayer._regen_hps = ADJ_REGEN_HPS
+        eventPlayer._passive_regen_delay = ADJ_REGEN_TIMER/2
+        eventPlayer._passive_regen_hps = ADJ_REGEN_HPS
     else: # everyone else
-        eventPlayer._regen_delay = ADJ_REGEN_TIMER
-        eventPlayer._regen_hps = ADJ_REGEN_HPS
+        eventPlayer._passive_regen_delay = ADJ_REGEN_TIMER
+        eventPlayer._passive_regen_hps = ADJ_REGEN_HPS
     
-    wait(eventPlayer._regen_delay, Wait.RESTART_WHEN_TRUE)
-    eventPlayer._regen_delay = 0
-    async(activateRegeneration, AsyncBehavior.RESTART)
+    if eventPlayer._passive_regen_delay > 0: setRegeneration(0)
+    wait(eventPlayer._passive_regen_delay, Wait.RESTART_WHEN_TRUE)
+    eventPlayer._passive_regen_delay = 0
+    
+    if eventPlayer.getHealth() < eventPlayer.getMaxHealth():
+        setRegeneration(eventPlayer._passive_regen_hps)
+
+    waitUntil(eventPlayer.getHealth() >= eventPlayer.getMaxHealth(), Math.INFINITY)
+    setRegeneration(0)
+
+
+def applyRegeneration():
+    @Name "[passives/support/self_heal.opy]: applyRegeneration()"
+
+    # do nothing if regen_hps didn't change
+    if eventPlayer._new_regen_hps == eventPlayer._current_regen_hps: return
+
+    # kill regen passive
+    if eventPlayer._new_regen_hps == 0:
+        stopHoT(eventPlayer._regen_passive_id)
+        eventPlayer._regen_passive_id = null
+        eventPlayer._current_regen_hps = 0
+    # update regen passive
+    else:
+        stopHoT(eventPlayer._regen_passive_id)
+        eventPlayer._regen_passive_id = null
+        eventPlayer.startHoT(null, Math.INFINITY, eventPlayer._new_regen_hps)
+        eventPlayer._regen_passive_id = getLastHoT()
+        eventPlayer._current_regen_hps = eventPlayer._new_regen_hps

--- a/src/passives/support/self_heal.opy
+++ b/src/passives/support/self_heal.opy
@@ -6,18 +6,18 @@ globalvar ADJ_REGEN_TIMER = createWorkshopSetting(int[1:30], 'Passive', 'Global 
 globalvar enable_support_passive = createWorkshopSetting(bool, 'Passive', 'Support - Quicker Regeneration', false, 0)
 
 playervar self_heal_pvar
-#!defineMember _self_healing_source self_heal_pvar[0]
-#!defineMember _self_healing_percent self_heal_pvar[1]
-#!defineMember _self_healing_id self_heal_pvar[2]
-#!defineMember _regen_passive_active self_heal_pvar[3]
-#!defineMember _last_time_damage_taken self_heal_pvar[4]
-#!defineMember _suppress_regen_passive self_heal_pvar[5]
-#!defineMember _support_passive_active self_heal_pvar[6]
-#!defineMember _regen_passive_id self_heal_pvar[7]
-#!defineMember _passive_regen_delay self_heal_pvar[8]
-#!defineMember _passive_regen_hps self_heal_pvar[9]
-#!defineMember _current_regen_hps self_heal_pvar[10]
-#!defineMember _new_regen_hps self_heal_pvar[11]
+playervar _self_healing_source
+playervar _self_healing_percent
+playervar _self_healing_id
+playervar _regen_passive_active
+playervar _last_time_damage_taken
+playervar _suppress_ow2_regen_passive
+playervar _support_passive_active
+playervar _regen_passive_id
+playervar _passive_regen_delay
+playervar _passive_regen_hps
+playervar _current_regen_hps
+playervar _new_regen_hps
 
 subroutine applyRegeneration
 subroutine startPassiveRegeneration
@@ -34,12 +34,14 @@ def resetSelfHealing():
     eventPlayer._self_healing_source = []
     eventPlayer._self_healing_percent = 0
     eventPlayer._regen_passive_active = true
-    eventPlayer._suppress_regen_passive = false
+    eventPlayer._suppress_ow2_regen_passive = false
     eventPlayer._support_passive_active = true
 
 
-#!define removeRegenPassive()\
-    eventPlayer._suppress_regen_passive = true
+def removeOW2RegenPassive():
+    @Name "[passives/support/self_heal.opy]: removeOW2RegenPassive()"
+
+    eventPlayer._suppress_ow2_regen_passive = true
 
 
 def removeSelfHealing():
@@ -52,9 +54,11 @@ def removeSelfHealing():
         eventPlayer._self_healing_id = getLastHealingModification()
 
 
-#!define evalSelfHealingPercent()\
-    eventPlayer._self_healing_percent = 100 if len(eventPlayer._self_healing_source) > 0 else 0\
-    eventPlayer._suppress_regen_passive = true if eventPlayer._self_healing_percent > 0 else false
+def evalSelfHealingPercent():
+    @Name "[passives/support/self_heal.opy]: evalSelfHealingPercent()"
+
+    eventPlayer._self_healing_percent = 100 if len(eventPlayer._self_healing_source) > 0 else 0
+    eventPlayer._suppress_ow2_regen_passive = true if eventPlayer._self_healing_percent > 0 else false
 
 
 #!define pushSelfHealing(button) \
@@ -84,9 +88,9 @@ rule "[passives/support/self_heal.opy]: Detect healing passive":
 
 
 # Deal damage to suppress regen passive except when regenerating shield hp
-rule "[passives/support/self_heal.opy]: Remove Passive self healing":
+rule "[passives/support/self_heal.opy]: Remove OW2 passive self healing":
     @Event eachPlayer
-    @Condition eventPlayer._suppress_regen_passive
+    @Condition eventPlayer._suppress_ow2_regen_passive
     @Condition eventPlayer._regen_passive_active or eventPlayer._support_passive_active
     @Condition eventPlayer.getHealthOfType(Health.SHIELDS) >= eventPlayer.getMaxHealthOfType(Health.SHIELDS)
     @Condition eventPlayer.getHealth() < eventPlayer.getMaxHealth()
@@ -135,7 +139,7 @@ def startPassiveRegeneration():
 def applyRegeneration():
     @Name "[passives/support/self_heal.opy]: applyRegeneration()"
 
-    # do nothing if regen_hps didn't change
+    # do nothing if regen hps didn't change
     if eventPlayer._new_regen_hps == eventPlayer._current_regen_hps: return
 
     # kill regen passive

--- a/src/utilities/debug.opy
+++ b/src/utilities/debug.opy
@@ -10,8 +10,7 @@ playervar debug_pvar
 #!define _total_healing_received debug_pvar[2]
 #!define _last_healing_received debug_pvar[3]
 
-#!include "utilities/hero_init.opy"
-#!include "heroes/mccree/peacekeeper.opy"
+#!include "passives/support/self_heal.opy"
 
 
 rule "[utilities/debug.opy] Disable Inspector for performance":
@@ -39,10 +38,13 @@ rule "[utilities/debug.opy]: player debug (Top Right)":
     @Condition DEBUG_MODE == true
 
     hudHeader(eventPlayer, "Event Player", HudPosition.RIGHT, 0, Color.WHITE, HudReeval.STRING)
-    hudSubheader(eventPlayer, "peacekeeper_distance = {}".format(eventPlayer.peacekeeper_distance), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "_regen_passive_id = {}".format(eventPlayer._regen_passive_id), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "_passive_regen_delay = {}".format(eventPlayer._passive_regen_delay), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "_current_regen_hps = {}".format(eventPlayer._current_regen_hps), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "_new_regen_hps = {}".format(eventPlayer._new_regen_hps), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+    # hudSubheader(eventPlayer, "peacekeeper_distance = {}".format(eventPlayer.peacekeeper_distance), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "hero_initialized = {}".format(eventPlayer.hero_initialized), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    #  hudSubheader(eventPlayer, "_regen_passive_id = {}".format(eventPlayer._regen_passive_id), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
-    #  hudSubheader(eventPlayer, "_regen_delay = {}".format(eventPlayer._regen_delay), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
+
     # hudSubheader(eventPlayer, "hero_setup = {}".format(eventPlayer.hero_setup), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "_last_hero_played = {}".format(eventPlayer._last_hero_played), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
     # hudSubheader(eventPlayer, "hasSpawned() = {}".format(eventPlayer.hasSpawned()), HudPosition.RIGHT, 1, Color.WHITE, HudReeval.STRING)
@@ -139,7 +141,7 @@ rule "[utilities/debug.opy]: do something on interact":
     @Condition eventPlayer.isHoldingButton(Button.INTERACT)
 
     # getAllPlayers().setHealth(1)
-    damage(eventPlayer, getClosestPlayer(eventPlayer, Team.2), 25)
+    damage(eventPlayer, getClosestPlayer(eventPlayer, getOppositeTeam(eventPlayer.getTeam())), 25/getClosestPlayer(eventPlayer, getOppositeTeam(eventPlayer.getTeam()))._base_damage_scalar)
     eventPlayer.setAbilityCooldown(Button.ABILITY_1, 0)
     eventPlayer.setAbilityCooldown(Button.ABILITY_2, 0)
     eventPlayer.setAbilityCooldown(Button.SECONDARY_FIRE, 0)


### PR DESCRIPTION
fix #61 

There is now only a single instance of regeneration HoT that is abstracted away through a macro function `setRegeneration(hps)`. This macro smartly handles all requests to change the regeneration rate without duplicating the HoT entity.

When mercy activates valkyrie, she calls `setRegeneration(20)`. When mercy takes damage during valkyrie, she waits 0 before calling `setRegeneration(20)`, but the HoT instance isn't duplicated. Whenever mercy takes damage without valkyrie, she waits 1 before calling `setRegeneration(20)`. 