### PR TITLE
cache cassidy falloff formula into vars

### DIFF
--- a/src/heroes/mccree/peacekeeper.opy
+++ b/src/heroes/mccree/peacekeeper.opy
@@ -1,14 +1,13 @@
 #!mainFile "../../dev_main.opy"
 
-
 # Damage falloff derived from Marblr's "How Damage Falloff is Calculated" video: https://youtu.be/VL2VnkNJPpE
-#!define ADJCASSIDYN(distance) ((distance - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(ADJ_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE))
-#!define OW2CASSIDYN(distance) ((distance - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(OW2_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE))
-#!define ADJCassidyFalloff(distance) clamp((ADJCASSIDYN(distance)) * ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - ADJCASSIDYN(distance)), ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR, 1)
-#!define OW2CassidyFalloff(distance) clamp((OW2CASSIDYN(distance)) * OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - OW2CASSIDYN(distance)), OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR, 1)
-#!define expectedCassidyDamage(distance) (eventDamage/eventPlayer._base_damage_scalar)*(ADJCassidyFalloff(distance)/OW2CassidyFalloff(distance))
 
 playervar peacekeeper_distance
+playervar adj_cassidy_n
+playervar ow2_cassidy_n
+playervar adj_cassidy_falloff
+playervar ow2_cassidy_falloff
+
 
 rule "[mccree/peacekeeper.opy]: Increase Peacekeeper falloff damage range":
     @Event playerDealtDamage
@@ -19,4 +18,9 @@ rule "[mccree/peacekeeper.opy]: Increase Peacekeeper falloff damage range":
     # since workshop doesn't provide exact hit coordinate, assume hit coordianate is the center mass of victim
     # then subtract some magic value as compensation for the inaccuracy
     eventPlayer.peacekeeper_distance = distance(attacker.getEyePosition(), centerMass(victim)) - 0.25
-    damage(victim, attacker, (expectedCassidyDamage(eventPlayer.peacekeeper_distance) - eventDamage)/eventPlayer._base_damage_scalar)
+    eventPlayer.adj_cassidy_n = (eventPlayer.peacekeeper_distance - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(ADJ_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - ADJ_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)
+    eventPlayer.ow2_cassidy_n = (eventPlayer.peacekeeper_distance - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)/(OW2_CASSIDY_DAMAGE_FALLOFF_END_DISTANCE - OW2_CASSIDY_DAMAGE_FALLOFF_START_DISTANCE)
+    eventPlayer.adj_cassidy_falloff = clamp(eventPlayer.adj_cassidy_n * ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - eventPlayer.adj_cassidy_n), ADJ_CASSIDY_DAMAGE_FALLOFF_SCALAR, 1)
+    eventPlayer.ow2_cassidy_falloff = clamp(eventPlayer.ow2_cassidy_n * OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR + (1 - eventPlayer.ow2_cassidy_n), OW2_CASSIDY_DAMAGE_FALLOFF_SCALAR, 1)
+
+    damage(victim, attacker, ((eventDamage/eventPlayer._base_damage_scalar)*(eventPlayer.adj_cassidy_falloff/eventPlayer.ow2_cassidy_falloff) - eventDamage)/eventPlayer._base_damage_scalar)

--- a/src/utilities/debug.opy
+++ b/src/utilities/debug.opy
@@ -1,7 +1,7 @@
 #!mainFile "../dev_main.opy"
 
 globalvar DEBUG_MODE = createWorkshopSetting(bool, "Dev Tools", "debug mode", true)
-#!define STAT_KEEP_ALIVE (2)
+#!define STAT_KEEP_ALIVE (1)
 #!define STAT_SPACING (0.5)
 
 playervar debug_pvar


### PR DESCRIPTION
Can't exactly confirm if this reduces server load in my practice range testing. Functionality is the same.

I tried holding m1 against reaper and recording the server load, and this one felt like it had slightly less peak server load.